### PR TITLE
🚀 Release 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "tree-sitter-python>=0.23.6",
   # Compiling issue on manylinux aarch64 image, so install from git instead of Pypi
   # https://github.com/tree-sitter/py-tree-sitter/issues/386#issuecomment-3101430799
-  "tree-sitter @ git+https://github.com/tree-sitter/py-tree-sitter@v0.25.1",
+  "tree-sitter>=0.25.1",
 
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "tree-sitter-python>=0.23.6",
   # Compiling issue on manylinux aarch64 image, so install from git instead of Pypi
   # https://github.com/tree-sitter/py-tree-sitter/issues/386#issuecomment-3101430799
-  "tree-sitter>=0.25.1",
+  "tree-sitter~=0.25.1",
 
 ]
 


### PR DESCRIPTION
The PR is to fix the error from the action to release the package in PyPi.
https://github.com/useblocks/sphinx-codelinks/actions/runs/17173108678

It seems PyPI does not allow direct VCS (git) dependencies, and it was used because the segment error from tree-sitter on manylinux aarch64 image.

 https://github.com/tree-sitter/py-tree-sitter/issues/386#issuecomment-3101430799

However, it seems tree-sitter has the workaround for it, so tree-sitter on PyPi can be used directly
https://github.com/tree-sitter/py-tree-sitter/pull/399
https://github.com/tree-sitter/py-tree-sitter/pull/393

