### PR TITLE
🐛 Validate field default ordering in oneline config

### DIFF
--- a/src/sphinx_codelinks/config.py
+++ b/src/sphinx_codelinks/config.py
@@ -276,11 +276,29 @@ class OneLineCommentStyle:
             needs_field_names.add(_field["name"])
         return errors
 
+    def check_fields_default_order(self) -> list[str]:
+        errors = []
+        seen_default = False
+        first_default_field = ""
+        for _field in self.needs_fields:
+            has_default = _field.get("default") is not None
+            if has_default and not seen_default:
+                seen_default = True
+                first_default_field = _field["name"]
+            elif not has_default and seen_default:
+                errors.append(
+                    f"Field '{_field['name']}' without a default follows "
+                    f"field '{first_default_field}' which has a default. "
+                    f"Fields without defaults must be defined before fields with defaults."
+                )
+        return errors
+
     def check_fields_configuration(self) -> list[str]:
         return (
             self.check_schema()
             + self.check_required_fields()
             + self.check_fields_mutually_exclusive()
+            + self.check_fields_default_order()
         )
 
     def get_cnt_required_fields(self) -> int:

--- a/tests/test_analyse_config.py
+++ b/tests/test_analyse_config.py
@@ -152,6 +152,24 @@ def test_config_schema_validator_negative(analyse_config, result):
                 "Missing required fields: ['title', 'type']",
             ],
         ),
+        (
+            OneLineCommentStyle(
+                start_sequence="@need",
+                end_sequence="\n",
+                field_split_char=",",
+                needs_fields=[
+                    {"name": "id"},
+                    {"name": "implements", "type": "list[str]", "default": []},
+                    {"name": "type", "default": "impl"},
+                    {"name": "title"},  # required after optional
+                ],
+            ),
+            [
+                "Missing required fields: ['type']",
+                "Field 'title' without a default follows field 'implements' which has a default. "
+                "Fields without defaults must be defined before fields with defaults.",
+            ],
+        ),
     ],
 )
 def test_oneline_schema_validator_negative(oneline_config, result):

--- a/tests/test_analyse_config.py
+++ b/tests/test_analyse_config.py
@@ -165,7 +165,6 @@ def test_config_schema_validator_negative(analyse_config, result):
                 ],
             ),
             [
-                "Missing required fields: ['type']",
                 "Field 'title' without a default follows field 'implements' which has a default. "
                 "Fields without defaults must be defined before fields with defaults.",
             ],


### PR DESCRIPTION
### Problem

The oneline parser maps comma-separated values to `needs_fields` strictly by position (index). When a field **without** a default is defined after a field **with** a default, it becomes unreachable if the user omits the optional fields — exactly like Python's `SyntaxError: parameter without a default follows parameter with a default`.

Example invalid configuration:

```toml
needs_fields = [
  { "name" = "id" },
  { "name" = "implements", "type" = "list[str]", "default" = [] },
  { "name" = "type", "default" = "impl" },
  { "name" = "title" },  # required, but comes after optional fields
]
```

With this config, `@need MY_ID, My Title` maps `My Title` to `implements` (index 1) instead of `title` (index 3), and `title` is silently skipped.

### Solution

Add `check_fields_default_order()` validation to `OneLineCommentStyle` that rejects configurations where a field without a default follows a field with a default. This is checked alongside existing schema, required-field, and uniqueness validations in `check_fields_configuration()`.

### Changes

- `config.py`: New `check_fields_default_order()` method, integrated into `check_fields_configuration()`
- `test_analyse_config.py`: Negative test case exercising the validation
