### PR TITLE
🔧 Allow Sphinx 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,14 @@ jobs:
           - os: ubuntu-latest
             python: "3.14"
             tox-env: py314-sphinx8-needs8
+          # Sphinx 9 with lowest compatible sphinx-needs
+          - os: ubuntu-latest
+            python: "3.12"
+            tox-env: py312-sphinx9-needs7
+          # Sphinx 9 with highest sphinx-needs
+          - os: ubuntu-latest
+            python: "3.14"
+            tox-env: py314-sphinx9-needs8
           # minimal version on Windows
           - os: windows-latest
             python: "3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "typer>=0.16.0",
   "click < 8.2",                # click 8.2.* produces empty errors if no args are given
   "jsonschema",
-  "sphinx>=7.4,<9",
+  "sphinx>=7.4,<10",
   "sphinx-needs>=5,<9",
   "jinja2",
   "pygments",


### PR DESCRIPTION
## Summary
- Bump the sphinx dependency upper bound from `<9` to `<10` so Sphinx 9 can be installed alongside `sphinx-codelinks`.

## Test plan
- [x] `tox -e py312-sphinx9-needs7` — 206 passed
- [x] `tox -e py312-sphinx9-needs8` — 206 passed
- [x] `tox -e py312-sphinx8-needs5` — 206 passed (no regression on the existing default env)

## Notes
Sphinx 9 is incompatible with `sphinx-needs <7` (needs 5/6 require `sphinx<9`), so users wanting Sphinx 9 will resolve to `sphinx-needs >=7`. The combined `sphinx-needs>=5,<9` constraint stays correct because pip resolves a compatible pair.

Some `RemovedInSphinx11Warning` deprecations surface from `sphinx-needs` and our extension code (`env.app` access, `add_extra_option`), but no tests fail on Sphinx 9.