### PR TITLE
Release 1.3.0

### DIFF
--- a/docs/source/development/change_log.rst
+++ b/docs/source/development/change_log.rst
@@ -3,16 +3,59 @@
 Changelog
 =========
 
-Upcoming
---------
+.. _`release:1.3.0`:
 
-- ⬆️ Support and test sphinx-needs v5-8
-- 📚 Documented C# language support in ``features.rst``
-- 🧪 Added Sphinx integration test for C# source files
+1.3.0
+-----
+
+:Released: 20.06.2026
+
+New and Improved
+................
+
 - ✨ Added Go parser for the ``analyse`` module.
 
   Need ID references and one-line need definitions can now be extracted from Go source files.
   The supported comment styles are ``//`` and ``/* */``.
+
+- ✨ Added JSONC language support for the ``analyse`` module.
+
+  Comments in JSONC files are now parsed for need ID references and one-line need definitions.
+  ``.json`` files are also checked when they begin with a comment (see jsonc.org).
+
+- 👌 Replaced ``gitignore-parser`` with ``ignore-python`` for source discovery.
+
+  This adds native nested ``.gitignore`` support, improves performance, and brings behavioral
+  parity with ubCode. A per-project ``follow_links`` configuration option was also added.
+
+- ⬆️ Support and test Sphinx-Needs v5-8.
+- ⬆️ Allow Sphinx 9.
+- 📚 Documented C# language support in ``features.rst``.
+- 🧪 Added a Sphinx integration test for C# source files.
+
+Fixes
+.....
+
+- 🐛 Register Sphinx-Needs fields with a typed schema.
+
+  The ``project``, ``file``, ``directory`` and URL fields are now registered with a typed
+  (string) schema, so they no longer trigger schema violations on needs that do not set them
+  when strict Sphinx-Needs schema validation is enabled.
+
+- 🐛 Do not mutate the ``rebuild='env'`` ``src_trace_projects`` configuration during builds.
+
+  Incremental Sphinx builds no longer re-read every document on each run.
+
+- 🐛 Route ``analyse`` logging through the active environment instead of installing a stderr
+  handler at import time.
+
+  Routine INFO progress no longer goes to stderr unconditionally, and importing the package no
+  longer forces a logging handler onto consumers.
+
+- 🐛 Validate field default ordering in the oneline configuration.
+
+  A required field defined after a field with a default is now reported as an error instead of
+  being silently skipped.
 
 .. _`release:1.2.0`:
 

--- a/docs/source/development/roadmap.rst
+++ b/docs/source/development/roadmap.rst
@@ -19,7 +19,6 @@ Source Code Parsing
 
 - Introduce a configurable option to strip leading characters (e.g., ``*``) from commented RST blocks.
 - Enrich tagged scopes with additional metadata.
-- ✅ Nested ``.gitignore`` files are now supported (implemented via ``ignore-python``).
 
 Defining Needs in Source Code
 -----------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sphinx-codelinks"
-version = "1.2.0"
+version = "1.3.0"
 description = "Fast Source Code Traceability for Sphinx-Needs"
 authors = [{ name = "team useblocks", email = "info@useblocks.com" }]
 maintainers = [


### PR DESCRIPTION
Prepares the **1.3.0** release.

## Release changes

- ⬆️ Bump version `1.2.0` → `1.3.0` in `pyproject.toml`.
- 📝 Finalize the changelog: convert the `Upcoming` heading into a dated `1.3.0` section. Only 3 of the 10 PRs merged since 1.2.0 had added changelog entries, so this also documents the 7 user-facing PRs that were missing one.
- 🗺️ Prune the completed "nested `.gitignore` support" item from the roadmap (shipped via #64).

## Changelog for 1.3.0

**New and Improved**

- ✨ Added Go parser for the `analyse` module (#79)
- ✨ Added JSONC language support for the `analyse` module (#70)
- 👌 Replaced `gitignore-parser` with `ignore-python` for source discovery; added per-project `follow_links` (#64)
- ⬆️ Support and test Sphinx-Needs v5-8 (#65)
- ⬆️ Allow Sphinx 9 (#68)
- 📚 Documented C# language support in `features.rst` (#78)
- 🧪 Added a Sphinx integration test for C# source files (#78)

**Fixes**

- 🐛 Register Sphinx-Needs fields with a typed schema (#80)
- 🐛 Don't mutate the `rebuild='env'` `src_trace_projects` config during builds (#75)
- 🐛 Route `analyse` logging by environment instead of a stderr handler at import (#73)
- 🐛 Validate field default ordering in the oneline config (#63)

## Verification

- `tox -e docs-clean` (`sphinx-build -nW`) builds successfully — 0 schema warnings.

## After merge

- Tag `1.3.0` on the merge commit (matching the existing `1.0.0`–`1.2.0` tags).
