### PR TITLE
🧪 Declarative fixture + snapshot extraction tests

### DIFF
--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[custom_config-bracketed_defaults_applied].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[custom_config-bracketed_defaults_applied].json
@@ -1,0 +1,20 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_1",
+      "title": "title 1",
+      "type": "impl",
+      "links": {
+        "links": []
+      },
+      "metadata": {
+        "status": "open",
+        "priority": "low"
+      },
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[custom_config-bracketed_two_links].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[custom_config-bracketed_two_links].json
@@ -1,0 +1,23 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_5",
+      "title": "title 5",
+      "type": "impl",
+      "links": {
+        "links": [
+          "SPEC_1",
+          "SPEC_2"
+        ]
+      },
+      "metadata": {
+        "status": "open",
+        "priority": "low"
+      },
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[custom_config-space_separated].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[custom_config-space_separated].json
@@ -1,0 +1,15 @@
+{
+  "needs": [
+    {
+      "id": "FEAT_001",
+      "title": "MyFeature",
+      "type": "feature",
+      "links": {},
+      "metadata": {},
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[custom_config-space_separated_defaults_applied].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[custom_config-space_separated_defaults_applied].json
@@ -1,0 +1,15 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_1",
+      "title": "Implementation",
+      "type": "impl",
+      "links": {},
+      "metadata": {},
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[escapes-escaped_backslash_in_str_field].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[escapes-escaped_backslash_in_str_field].json
@@ -1,0 +1,22 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_13",
+      "title": "title\\ 13",
+      "type": "impl",
+      "links": {
+        "links": [
+          "[SPEC,_1]"
+        ]
+      },
+      "metadata": {
+        "status": "open",
+        "priority": "low"
+      },
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[escapes-escaped_brackets_in_list_item].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[escapes-escaped_brackets_in_list_item].json
@@ -1,0 +1,22 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_12",
+      "title": "title 12",
+      "type": "impl",
+      "links": {
+        "links": [
+          "[SPEC,_1]"
+        ]
+      },
+      "metadata": {
+        "status": "open",
+        "priority": "low"
+      },
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[escapes-escaped_comma_in_list_item].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[escapes-escaped_comma_in_list_item].json
@@ -1,0 +1,22 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_11",
+      "title": "title 11",
+      "type": "impl",
+      "links": {
+        "links": [
+          "SPEC,_1"
+        ]
+      },
+      "metadata": {
+        "status": "open",
+        "priority": "low"
+      },
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[escapes-escaped_comma_in_str_field_default].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[escapes-escaped_comma_in_str_field_default].json
@@ -1,0 +1,17 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_3",
+      "title": "title, 3",
+      "type": "impl",
+      "links": {
+        "links": []
+      },
+      "metadata": {},
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[extra_languages-default_oneliner_go].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[extra_languages-default_oneliner_go].json
@@ -1,0 +1,19 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_GO",
+      "title": "Go Title",
+      "type": "impl",
+      "links": {
+        "links": [
+          "REQ_GO"
+        ]
+      },
+      "metadata": {},
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[extra_languages-default_oneliner_jsonc].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[extra_languages-default_oneliner_jsonc].json
@@ -1,0 +1,19 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_JSONC",
+      "title": "Jsonc Title",
+      "type": "impl",
+      "links": {
+        "links": [
+          "REQ_JSONC"
+        ]
+      },
+      "metadata": {},
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[marked_rst-multi_line_rst_doxygen].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[marked_rst-multi_line_rst_doxygen].json
@@ -1,0 +1,12 @@
+{
+  "needs": [],
+  "need_refs": [],
+  "marked_rst": [
+    {
+      "content": " .. impl:: Multi\n    :id: M_1\n\n    Body line.\n ",
+      "start_line": 3,
+      "end_line": 3
+    }
+  ],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[marked_rst-single_line_rst].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[marked_rst-single_line_rst].json
@@ -1,0 +1,12 @@
+{
+  "needs": [],
+  "need_refs": [],
+  "marked_rst": [
+    {
+      "content": " .. impl:: X\\n   :id: Y\\n",
+      "start_line": 2,
+      "end_line": 2
+    }
+  ],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[need_refs-custom_marker].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[need_refs-custom_marker].json
@@ -1,0 +1,15 @@
+{
+  "needs": [],
+  "need_refs": [
+    {
+      "need_id": "REQ_A",
+      "line": 1
+    },
+    {
+      "need_id": "REQ_B",
+      "line": 1
+    }
+  ],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[need_refs-default_marker].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[need_refs-default_marker].json
@@ -1,0 +1,19 @@
+{
+  "needs": [],
+  "need_refs": [
+    {
+      "need_id": "REQ_1",
+      "line": 1
+    },
+    {
+      "need_id": "REQ_2",
+      "line": 1
+    },
+    {
+      "need_id": "REQ_3",
+      "line": 1
+    }
+  ],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[need_refs-default_marker_python].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[need_refs-default_marker_python].json
@@ -1,0 +1,11 @@
+{
+  "needs": [],
+  "need_refs": [
+    {
+      "need_id": "REQ_1",
+      "line": 1
+    }
+  ],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[oneline-default_oneliner_c].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[oneline-default_oneliner_c].json
@@ -1,0 +1,19 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_C",
+      "title": "C Title",
+      "type": "impl",
+      "links": {
+        "links": [
+          "REQ_C"
+        ]
+      },
+      "metadata": {},
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[oneline-default_oneliner_cpp].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[oneline-default_oneliner_cpp].json
@@ -1,0 +1,19 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_1",
+      "title": "My Title",
+      "type": "impl",
+      "links": {
+        "links": [
+          "REQ_1"
+        ]
+      },
+      "metadata": {},
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[oneline-default_oneliner_csharp].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[oneline-default_oneliner_csharp].json
@@ -1,0 +1,19 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_CS",
+      "title": "Cs Title",
+      "type": "impl",
+      "links": {
+        "links": [
+          "REQ_CS"
+        ]
+      },
+      "metadata": {},
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[oneline-default_oneliner_python].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[oneline-default_oneliner_python].json
@@ -1,0 +1,19 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_PY",
+      "title": "Py Title",
+      "type": "impl",
+      "links": {
+        "links": [
+          "REQ_PY"
+        ]
+      },
+      "metadata": {},
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[oneline-default_oneliner_rust].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[oneline-default_oneliner_rust].json
@@ -1,0 +1,19 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_RS",
+      "title": "Rs Title",
+      "type": "impl",
+      "links": {
+        "links": [
+          "REQ_RS"
+        ]
+      },
+      "metadata": {},
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[oneline-default_oneliner_yaml].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[oneline-default_oneliner_yaml].json
@@ -1,0 +1,19 @@
+{
+  "needs": [
+    {
+      "id": "IMPL_YAML",
+      "title": "Yaml Title",
+      "type": "impl",
+      "links": {
+        "links": [
+          "REQ_YAML"
+        ]
+      },
+      "metadata": {},
+      "line": 1
+    }
+  ],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": []
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[warnings-missing_square_brackets].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[warnings-missing_square_brackets].json
@@ -1,0 +1,11 @@
+{
+  "needs": [],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": [
+    {
+      "kind": "missing_square_brackets",
+      "line": 1
+    }
+  ]
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[warnings-not_start_or_end_with_square_brackets].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[warnings-not_start_or_end_with_square_brackets].json
@@ -1,0 +1,11 @@
+{
+  "needs": [],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": [
+    {
+      "kind": "not_start_or_end_with_square_brackets",
+      "line": 1
+    }
+  ]
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[warnings-too_few_fields].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[warnings-too_few_fields].json
@@ -1,0 +1,11 @@
+{
+  "needs": [],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": [
+    {
+      "kind": "too_few_fields",
+      "line": 1
+    }
+  ]
+}

--- a/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[warnings-too_many_fields].json
+++ b/tests/__snapshots__/test_extraction_fixtures/test_extraction_fixture[warnings-too_many_fields].json
@@ -1,0 +1,11 @@
+{
+  "needs": [],
+  "need_refs": [],
+  "marked_rst": [],
+  "warnings": [
+    {
+      "kind": "too_many_fields",
+      "line": 1
+    }
+  ]
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,3 +101,21 @@ def snapshot_marks(snapshot):
     Sanitize the reqif, to make the snapshots reproducible.
     """
     return snapshot.with_defaults(extension_class=AnchorsSnapshotExtension)
+
+
+class ExtractionSnapshotExtension(SingleFileSnapshotExtension):
+    """Single-file JSON snapshots for the declarative extraction tests."""
+
+    _write_mode = WriteMode.TEXT
+    file_extension = "json"
+
+    def serialize(self, data, **_kwargs):
+        if not isinstance(data, dict):
+            raise TypeError(f"Expected dict, got {type(data)}")
+        return json.dumps(data, indent=2)
+
+
+@pytest.fixture
+def snapshot_extraction(snapshot):
+    """Snapshot fixture for the normalized extraction output (one JSON per case)."""
+    return snapshot.with_defaults(extension_class=ExtractionSnapshotExtension)

--- a/tests/data/extraction/README.md
+++ b/tests/data/extraction/README.md
@@ -37,6 +37,10 @@ custom_brackets_c:
 - `config: default` uses the built-in `OneLineCommentStyle` default
   (`@` / newline / `,` with fields `title, id, type(default "impl"), links(list)`).
 - Field `type` is `str` or `list[str]`.
+- `extract` (optional): which extractors to run — a subset of
+  `[oneline, need_refs, rst]` (default: all three). Narrow it to keep a case
+  focused: a need-reference case sets `extract: [need_refs]` so the `@`-prefixed
+  `@need-ids:` marker isn't also parsed as a one-line need.
 
 ## Snapshot (expected output) — normalized contract
 

--- a/tests/data/extraction/README.md
+++ b/tests/data/extraction/README.md
@@ -1,0 +1,71 @@
+# Declarative extraction-test fixtures
+
+Marker extraction (comment → one-line need / need-id-reference / marked-rst) is
+tested declaratively: each case is a **fixture** (the input) plus a **snapshot**
+(the captured expected output). This keeps the inputs language-agnostic and the
+expected output reviewable, and lets us cover the whole language matrix without a
+bespoke test function per case.
+
+## Fixture format
+
+Each `*.yaml` file in this directory is a map of `case_name → case`:
+
+```yaml
+default_oneliner_cpp:
+  lang: cpp                 # cpp | c | python | csharp | rust | yaml | go | jsonc
+  config: default          # "default", or an inline config block (see below)
+  source: |
+    // @My Title, IMPL_1, impl, [REQ_1]
+    void f() {}
+
+custom_brackets_c:
+  lang: c
+  config:
+    start_sequence: "[["
+    end_sequence: "]]"
+    field_split_char: ","
+    needs_fields:
+      - {name: title, type: str}
+      - {name: id, type: str}
+      - {name: type, type: str, default: impl}
+      - {name: links, type: "list[str]", default: []}
+    need_id_markers: ["@need-ids:"]   # optional; default ["@need-ids:"]
+  source: |
+    /* [[A Title, ID_1, impl, [REQ_1]]] */
+```
+
+- `config: default` uses the built-in `OneLineCommentStyle` default
+  (`@` / newline / `,` with fields `title, id, type(default "impl"), links(list)`).
+- Field `type` is `str` or `list[str]`.
+
+## Snapshot (expected output) — normalized contract
+
+Each case is run through the extractor and the result is normalized to this JSON
+shape, then compared to a committed snapshot under
+`tests/__snapshots__/extraction/`:
+
+```json
+{
+  "needs":      [{"id": "", "title": "", "type": "", "links": {"field": ["..."]}, "line": 1}],
+  "need_refs":  [{"need_id": "", "line": 1}],
+  "marked_rst": [{"content": "", "start_line": 1, "end_line": 1}],
+  "warnings":   [{"kind": "too_many_fields", "line": 1}]
+}
+```
+
+Lines are 1-indexed. `needs`/`warnings` are sorted by line; `need_refs` by
+`(line, need_id)`. Volatile data (file paths, columns, URLs, tagged scope) is
+omitted so snapshots are stable.
+
+## Running / updating
+
+```bash
+# run the declarative extraction tests
+python -m pytest tests/test_extraction_fixtures.py
+
+# review + accept snapshot changes after editing fixtures or the extractor
+python -m pytest tests/test_extraction_fixtures.py --snapshot-update
+```
+
+Adding a case is just a new entry in a `*.yaml` file here, then
+`--snapshot-update` to capture its snapshot (review the diff before committing).

--- a/tests/data/extraction/custom_config.yaml
+++ b/tests/data/extraction/custom_config.yaml
@@ -1,0 +1,74 @@
+# Non-default one-line comment configurations.
+#
+# (a) A bracketed multi-field config (``[[`` / ``]]``, six fields). The two extra
+#     str fields (``status``, ``priority``) are not core (id/title/type) and not
+#     list fields, so the harness surfaces them under ``metadata`` in the snapshot.
+# (b) A space-separated config (``@`` start, newline end, `` `` split char) with
+#     three fields ``title id type``.
+
+bracketed_defaults_applied:
+  # Only id + title given; type/links/status/priority fall back to their defaults.
+  # status=open and priority=low appear under ``metadata``.
+  lang: cpp
+  config:
+    start_sequence: "[["
+    end_sequence: "]]"
+    field_split_char: ","
+    needs_fields:
+      - {name: id}
+      - {name: title}
+      - {name: type, default: impl}
+      - {name: links, type: "list[str]", default: []}
+      - {name: status, default: open}
+      - {name: priority, default: low}
+  source: |
+    /* [[IMPL_1, title 1]] */
+    void f() {}
+
+bracketed_two_links:
+  # All fields given explicitly; links holds two ids and status=open is explicit.
+  lang: cpp
+  config:
+    start_sequence: "[["
+    end_sequence: "]]"
+    field_split_char: ","
+    needs_fields:
+      - {name: id}
+      - {name: title}
+      - {name: type, default: impl}
+      - {name: links, type: "list[str]", default: []}
+      - {name: status, default: open}
+      - {name: priority, default: low}
+  source: |
+    /* [[IMPL_5, title 5, impl, [SPEC_1, SPEC_2], open]] */
+    void f() {}
+
+space_separated:
+  # Space as the field split char: title=MyFeature, id=FEAT_001, type=feature.
+  lang: cpp
+  config:
+    start_sequence: "@"
+    end_sequence: "\n"
+    field_split_char: " "
+    needs_fields:
+      - {name: title}
+      - {name: id}
+      - {name: type, default: impl}
+  source: |
+    // @MyFeature FEAT_001 feature
+    void f() {}
+
+space_separated_defaults_applied:
+  # Space-separated config with only title + id given; type defaults to impl.
+  lang: cpp
+  config:
+    start_sequence: "@"
+    end_sequence: "\n"
+    field_split_char: " "
+    needs_fields:
+      - {name: title}
+      - {name: id}
+      - {name: type, default: impl}
+  source: |
+    // @Implementation IMPL_1
+    void f() {}

--- a/tests/data/extraction/escapes.yaml
+++ b/tests/data/extraction/escapes.yaml
@@ -1,0 +1,70 @@
+# Escape-sequence handling in one-line fields.
+#
+# In YAML ``source: |`` block scalars backslashes are literal, so the comment
+# text below is byte-for-byte what the extractor sees. ESCAPE is ``\``.
+#
+# The bracketed multi-field config (``[[`` / ``]]`` with id, title, type, links,
+# status, priority) is used for the list-field and str-field backslash cases so
+# the escaped chars land in a ``list[str]`` field and a trailing ``str`` field.
+
+escaped_comma_in_list_item:
+  # ``[SPEC\,_1]`` -> a single link literally containing a comma: ``SPEC,_1``.
+  lang: cpp
+  config:
+    start_sequence: "[["
+    end_sequence: "]]"
+    field_split_char: ","
+    needs_fields:
+      - {name: id}
+      - {name: title}
+      - {name: type, default: impl}
+      - {name: links, type: "list[str]", default: []}
+      - {name: status, default: open}
+      - {name: priority, default: low}
+  source: |
+    /* [[IMPL_11, title 11, impl, [SPEC\,_1], open]] */
+    void f() {}
+
+escaped_brackets_in_list_item:
+  # ``[\[SPEC\,_1\]]`` -> one link literally containing brackets: ``[SPEC,_1]``.
+  lang: cpp
+  config:
+    start_sequence: "[["
+    end_sequence: "]]"
+    field_split_char: ","
+    needs_fields:
+      - {name: id}
+      - {name: title}
+      - {name: type, default: impl}
+      - {name: links, type: "list[str]", default: []}
+      - {name: status, default: open}
+      - {name: priority, default: low}
+  source: |
+    /* [[IMPL_12, title 12, impl, [\[SPEC\,_1\]], open]] */
+    void f() {}
+
+escaped_backslash_in_str_field:
+  # ``title\\ 13`` (escaped backslash in a str field) -> ``title\ 13``.
+  lang: cpp
+  config:
+    start_sequence: "[["
+    end_sequence: "]]"
+    field_split_char: ","
+    needs_fields:
+      - {name: id}
+      - {name: title}
+      - {name: type, default: impl}
+      - {name: links, type: "list[str]", default: []}
+      - {name: status, default: open}
+      - {name: priority, default: low}
+  source: |
+    /* [[IMPL_13, title\\ 13, impl, [\[SPEC\,_1\]], open]] */
+    void f() {}
+
+escaped_comma_in_str_field_default:
+  # Default config: an escaped comma in the ``title`` str field -> ``title, 3``.
+  lang: cpp
+  config: default
+  source: |
+    // @title\, 3, IMPL_3
+    void f() {}

--- a/tests/data/extraction/extra_languages.yaml
+++ b/tests/data/extraction/extra_languages.yaml
@@ -1,0 +1,13 @@
+default_oneliner_go:
+  lang: go
+  config: default
+  source: |
+    // @Go Title, IMPL_GO, impl, [REQ_GO]
+    func f() {}
+
+default_oneliner_jsonc:
+  lang: jsonc
+  config: default
+  source: |
+    // @Jsonc Title, IMPL_JSONC, impl, [REQ_JSONC]
+    { "k": 1 }

--- a/tests/data/extraction/marked_rst.yaml
+++ b/tests/data/extraction/marked_rst.yaml
@@ -1,0 +1,39 @@
+# Marked reStructuredText blocks (``@rst`` ... ``@endrst``) inside comments.
+# cpp only. Default marked-rst markers (@rst / @endrst) are used. These cases set
+# ``extract: [rst]`` so only rst extraction runs (the ``@rst`` / ``@endrst`` lines
+# also begin with ``@``, so running the one-line parser here would add noise).
+#
+# In the snapshot, marked_rst entries carry ``content`` plus ``start_line`` and
+# ``end_line`` (both 1-indexed; the extractor maps both to the row of the @rst
+# marker, so they coincide). For a single-line block the content is the verbatim
+# text between the markers (leading/trailing spaces kept). For a multi-line block
+# the rst starts on the line after @rst, ends before @endrst, and the leading
+# ``*`` of each doxygen line is stripped from the content.
+
+single_line_rst:
+  # @rst and @endrst on one line inside a /* */ block comment. Backslashes in a
+  # YAML ``|`` scalar are literal, so ``\n`` here is the two-char sequence, not a
+  # real newline -- the block stays single-line and content is kept verbatim.
+  lang: cpp
+  config: default
+  extract: [rst]
+  source: |
+    /* @rst .. impl:: X\n   :id: Y\n@endrst */
+    void f() {}
+
+multi_line_rst_doxygen:
+  # A doxygen /** ... */ block with a leading ``*`` on each line; confirm the
+  # leading ``*`` is stripped from the extracted content.
+  lang: cpp
+  config: default
+  extract: [rst]
+  source: |
+    /**
+     * @rst
+     * .. impl:: Multi
+     *    :id: M_1
+     *
+     *    Body line.
+     * @endrst
+     */
+    void f() {}

--- a/tests/data/extraction/need_refs.yaml
+++ b/tests/data/extraction/need_refs.yaml
@@ -1,0 +1,36 @@
+# Need-id references (``need_refs`` in the snapshot).
+#
+# The marker list comes from ``need_id_markers`` in the config block (the harness
+# wires it into NeedIdRefsConfig); the default marker is ``@need-ids:``. These
+# cases set ``extract: [need_refs]`` so only reference extraction runs (the
+# default one-line start is also ``@``, so running the one-line parser here would
+# add unrelated noise).
+
+default_marker:
+  # Default ``@need-ids:`` marker -> three need_refs (REQ_1, REQ_2, REQ_3).
+  lang: cpp
+  config: default
+  extract: [need_refs]
+  source: |
+    // @need-ids: REQ_1, REQ_2, REQ_3
+    void f() {}
+
+custom_marker:
+  # Custom marker ``REFS:`` via need_id_markers -> two need_refs (REQ_A, REQ_B).
+  lang: cpp
+  config:
+    need_id_markers: ["REFS:"]
+  extract: [need_refs]
+  source: |
+    // REFS: REQ_A, REQ_B
+    void f() {}
+
+default_marker_python:
+  # Same default marker, different source language (Python ``#`` comment).
+  lang: python
+  config: default
+  extract: [need_refs]
+  source: |
+    # @need-ids: REQ_1
+    def f():
+        pass

--- a/tests/data/extraction/oneline.yaml
+++ b/tests/data/extraction/oneline.yaml
@@ -1,0 +1,42 @@
+default_oneliner_cpp:
+  lang: cpp
+  config: default
+  source: |
+    // @My Title, IMPL_1, impl, [REQ_1]
+    void f() {}
+
+default_oneliner_c:
+  lang: c
+  config: default
+  source: |
+    // @C Title, IMPL_C, impl, [REQ_C]
+    void g(void) {}
+
+default_oneliner_python:
+  lang: python
+  config: default
+  source: |
+    # @Py Title, IMPL_PY, impl, [REQ_PY]
+    def f():
+        pass
+
+default_oneliner_csharp:
+  lang: csharp
+  config: default
+  source: |
+    // @Cs Title, IMPL_CS, impl, [REQ_CS]
+    class C {}
+
+default_oneliner_rust:
+  lang: rust
+  config: default
+  source: |
+    // @Rs Title, IMPL_RS, impl, [REQ_RS]
+    fn f() {}
+
+default_oneliner_yaml:
+  lang: yaml
+  config: default
+  source: |
+    # @Yaml Title, IMPL_YAML, impl, [REQ_YAML]
+    key: value

--- a/tests/data/extraction/warnings.yaml
+++ b/tests/data/extraction/warnings.yaml
@@ -1,0 +1,53 @@
+# One-line parser warnings. Each ``kind`` is a snake_case string under
+# ``warnings`` in the snapshot. The default config (4 fields: title, id, type,
+# links) is used unless a kind needs otherwise.
+
+too_many_fields:
+  # 5 fields supplied, config defines 4 -> too_many_fields.
+  lang: cpp
+  config: default
+  source: |
+    // @title, IMPL_1, impl, [REQ_1], extra
+    void f() {}
+
+too_few_fields:
+  # Only one field supplied; title + type are required (2) -> too_few_fields.
+  lang: cpp
+  config: default
+  source: |
+    // @only
+    void f() {}
+
+missing_square_brackets:
+  # links is type list[str] but given without ``[ ]`` -> missing_square_brackets.
+  lang: cpp
+  config: default
+  source: |
+    // @title, IMPL_1, impl, REQ_1
+    void f() {}
+
+not_start_or_end_with_square_brackets:
+  # links given as ``x[REQ]`` (does not start with ``[``)
+  # -> not_start_or_end_with_square_brackets.
+  lang: cpp
+  config: default
+  source: |
+    // @title, IMPL_1, impl, x[REQ]
+    void f() {}
+
+# NOTE: newline_in_field is intentionally absent.
+#
+# This warning fires only when ``oneline_parser`` receives a single string whose
+# extracted field span contains an interior newline (``is_newline_in_field``).
+# The analyse pipeline, however, runs the parser per *physical line*:
+# ``SourceAnalyse.extract_oneline_need`` does ``text.splitlines(keepends=True)``
+# and parses each element separately, so no string handed to the parser ever
+# contains an interior newline (only a trailing one, which the end_sequence
+# consumes). Block comments spanning lines therefore degrade to other warnings
+# (e.g. too_few_fields / missing_square_brackets) instead.
+#
+# A genuine block-comment attempt -- ``/* @title]] <newline> , IMPL */`` -- was
+# tried and produced too_few_fields on the first line, not newline_in_field.
+# The kind is reachable only via a direct ``oneline_parser`` unit call (see
+# tests/test_oneline_parser.py), which this declarative harness does not do, so
+# it cannot be triggered here without faking it. Left out deliberately.

--- a/tests/test_extraction_fixtures.py
+++ b/tests/test_extraction_fixtures.py
@@ -120,6 +120,11 @@ def test_extraction_fixture(case: dict, tmp_path: Path, snapshot_extraction) -> 
     markers = config.get("need_id_markers") if isinstance(config, dict) else None
     refs_config = NeedIdRefsConfig(markers=markers) if markers else NeedIdRefsConfig()
 
+    # Which extractors to run. Defaults to all; a fixture narrows this (e.g. a
+    # need-refs case sets ``extract: [need_refs]``) so unrelated markers — like
+    # ``@need-ids:`` matching the ``@`` one-line start — don't add noise.
+    extract = case.get("extract", ["oneline", "need_refs", "rst"])
+
     src_path = tmp_path / f"case.{ext}"
     src_path.write_text(case["source"], encoding="utf-8")
 
@@ -127,9 +132,9 @@ def test_extraction_fixture(case: dict, tmp_path: Path, snapshot_extraction) -> 
         src_files=[src_path],
         src_dir=tmp_path,
         comment_type=comment_type,
-        get_oneline_needs=True,
-        get_need_id_refs=True,
-        get_rst=True,
+        get_oneline_needs="oneline" in extract,
+        get_need_id_refs="need_refs" in extract,
+        get_rst="rst" in extract,
         oneline_comment_style=style,
         need_id_refs_config=refs_config,
     )

--- a/tests/test_extraction_fixtures.py
+++ b/tests/test_extraction_fixtures.py
@@ -5,7 +5,6 @@ Each case in ``tests/data/extraction/*.yaml`` supplies an input (``lang`` +
 compared to a committed JSON snapshot. See ``tests/data/extraction/README.md``.
 """
 
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -86,8 +85,7 @@ def _normalize(analyse: SourceAnalyse, style: OneLineCommentStyle) -> dict:
     need_refs = []
     for ref in analyse.need_id_refs:
         line = ref.source_map["start"]["row"] + 1
-        for need_id in ref.need_ids:
-            need_refs.append({"need_id": need_id, "line": line})
+        need_refs.extend({"need_id": need_id, "line": line} for need_id in ref.need_ids)
     need_refs.sort(key=lambda d: (d["line"], d["need_id"]))
 
     marked_rst = [
@@ -116,11 +114,10 @@ def _normalize(analyse: SourceAnalyse, style: OneLineCommentStyle) -> dict:
 @pytest.mark.parametrize("case", _load_cases())
 def test_extraction_fixture(case: dict, tmp_path: Path, snapshot_extraction) -> None:
     comment_type, ext = LANG_MAP[case["lang"]]
-    style = _build_oneline_style(case.get("config"))
+    config = case.get("config")
+    style = _build_oneline_style(config)
 
-    markers = case.get("config", {}).get("need_id_markers") if isinstance(
-        case.get("config"), dict
-    ) else None
+    markers = config.get("need_id_markers") if isinstance(config, dict) else None
     refs_config = NeedIdRefsConfig(markers=markers) if markers else NeedIdRefsConfig()
 
     src_path = tmp_path / f"case.{ext}"

--- a/tests/test_extraction_fixtures.py
+++ b/tests/test_extraction_fixtures.py
@@ -1,0 +1,144 @@
+"""Declarative marker-extraction tests.
+
+Each case in ``tests/data/extraction/*.yaml`` supplies an input (``lang`` +
+``config`` + ``source``); the extractor is run on it and the normalized output is
+compared to a committed JSON snapshot. See ``tests/data/extraction/README.md``.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from sphinx_codelinks.analyse.analyse import SourceAnalyse
+from sphinx_codelinks.config import (
+    NeedIdRefsConfig,
+    OneLineCommentStyle,
+    SourceAnalyseConfig,
+)
+from sphinx_codelinks.source_discover.config import CommentType
+
+FIXTURE_DIR = Path(__file__).parent / "data" / "extraction"
+
+# fixture ``lang`` -> (comment type, source-file extension)
+LANG_MAP: dict[str, tuple[CommentType, str]] = {
+    "cpp": (CommentType.cpp, "cpp"),
+    "c": (CommentType.cpp, "c"),
+    "python": (CommentType.python, "py"),
+    "csharp": (CommentType.cs, "cs"),
+    "rust": (CommentType.rust, "rs"),
+    "yaml": (CommentType.yaml, "yaml"),
+    "go": (CommentType.go, "go"),
+    "jsonc": (CommentType.jsonc, "jsonc"),
+}
+
+
+def _load_cases() -> list:
+    cases = []
+    for path in sorted(FIXTURE_DIR.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for name, case in data.items():
+            cases.append(pytest.param(case, id=f"{path.stem}-{name}"))
+    return cases
+
+
+def _build_oneline_style(config) -> OneLineCommentStyle:
+    if config in (None, "default"):
+        return OneLineCommentStyle()
+    kwargs = {
+        key: config[key]
+        for key in ("start_sequence", "end_sequence", "field_split_char")
+        if key in config
+    }
+    if "needs_fields" in config:
+        kwargs["needs_fields"] = config["needs_fields"]
+    return OneLineCommentStyle(**kwargs)
+
+
+def _list_field_names(style: OneLineCommentStyle) -> set[str]:
+    return {f["name"] for f in style.needs_fields if f.get("type") == "list[str]"}
+
+
+def _normalize(analyse: SourceAnalyse, style: OneLineCommentStyle) -> dict:
+    core = {"id", "title", "type"}
+    list_fields = _list_field_names(style)
+
+    needs = []
+    for n in analyse.oneline_needs:
+        need = n.need
+        links = {name: need[name] for name in list_fields if name in need}
+        metadata = {
+            k: v for k, v in need.items() if k not in core and k not in list_fields
+        }
+        needs.append(
+            {
+                "id": need.get("id", ""),
+                "title": need.get("title", ""),
+                "type": need.get("type", ""),
+                "links": links,
+                "metadata": metadata,
+                "line": n.source_map["start"]["row"] + 1,
+            }
+        )
+    needs.sort(key=lambda d: (d["line"], d["id"]))
+
+    need_refs = []
+    for ref in analyse.need_id_refs:
+        line = ref.source_map["start"]["row"] + 1
+        for need_id in ref.need_ids:
+            need_refs.append({"need_id": need_id, "line": line})
+    need_refs.sort(key=lambda d: (d["line"], d["need_id"]))
+
+    marked_rst = [
+        {
+            "content": m.rst,
+            "start_line": m.source_map["start"]["row"] + 1,
+            "end_line": m.source_map["end"]["row"] + 1,
+        }
+        for m in analyse.marked_rst
+    ]
+    marked_rst.sort(key=lambda d: d["start_line"])
+
+    warnings = [
+        {"kind": w.sub_type, "line": w.lineno} for w in analyse.oneline_warnings
+    ]
+    warnings.sort(key=lambda d: (d["line"], d["kind"]))
+
+    return {
+        "needs": needs,
+        "need_refs": need_refs,
+        "marked_rst": marked_rst,
+        "warnings": warnings,
+    }
+
+
+@pytest.mark.parametrize("case", _load_cases())
+def test_extraction_fixture(case: dict, tmp_path: Path, snapshot_extraction) -> None:
+    comment_type, ext = LANG_MAP[case["lang"]]
+    style = _build_oneline_style(case.get("config"))
+
+    markers = case.get("config", {}).get("need_id_markers") if isinstance(
+        case.get("config"), dict
+    ) else None
+    refs_config = NeedIdRefsConfig(markers=markers) if markers else NeedIdRefsConfig()
+
+    src_path = tmp_path / f"case.{ext}"
+    src_path.write_text(case["source"], encoding="utf-8")
+
+    cfg = SourceAnalyseConfig(
+        src_files=[src_path],
+        src_dir=tmp_path,
+        comment_type=comment_type,
+        get_oneline_needs=True,
+        get_need_id_refs=True,
+        get_rst=True,
+        oneline_comment_style=style,
+        need_id_refs_config=refs_config,
+    )
+    analyse = SourceAnalyse(cfg)
+    analyse.git_remote_url = None
+    analyse.git_commit_rev = None
+    analyse.run()
+
+    assert snapshot_extraction == _normalize(analyse, style)


### PR DESCRIPTION
## What

Adds a declarative **fixture + snapshot** test layer for C/C++/… marker
extraction. Each case is a YAML fixture (input: `lang` + `config` + `source`)
plus a captured JSON snapshot (expected: the normalized extraction output), so
the whole language matrix is covered as data rather than as bespoke test
functions.

## Details

- **Harness** `tests/test_extraction_fixtures.py` — parametrizes over
  `tests/data/extraction/*.yaml`, runs `SourceAnalyse` on a temp source file,
  normalizes the result to `{needs, need_refs, marked_rst, warnings}` (1-indexed
  lines), and asserts a single-file JSON snapshot per case (via a new
  `ExtractionSnapshotExtension` in `conftest.py`).
- **Fixtures** (`tests/data/extraction/`): default one-liners across all eight
  languages (cpp, c, python, csharp, rust, yaml, go, jsonc); escape-sequence
  resolution; custom one-line configs (bracketed + space-separated); need-id
  references (default + custom marker); four parser warning kinds; and
  `@rst`/`@endrst` blocks.
- Optional per-case `extract` toggle (subset of `oneline`/`need_refs`/`rst`)
  keeps a case focused so, e.g., a `@need-ids:` marker isn't also parsed as a
  one-line need.
- Fixture format + how-to-update are documented in
  `tests/data/extraction/README.md`.

## Scope

Test-only; no library changes. Covers the marker-extraction surface; existing
parser / pipeline / discovery tests are untouched. (`newline_in_field` is
reachable only at the parser level — noted in `warnings.yaml`.)

## Running

```
python -m pytest tests/test_extraction_fixtures.py
python -m pytest tests/test_extraction_fixtures.py --snapshot-update   # review + accept changes
```
