### PR TITLE
fix(docs): cap typer <0.26.8 (0.26.8 broke the Documentation build)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">= 3.12"
 dependencies = [
   "comment-parser>=1.2.4",
   "ignore-python>=0.3.3",
-  "typer>=0.16.0",
+  "typer>=0.16.0,<0.26.8",      # 0.26.8 removed rich_utils.STYLE_METAVAR, still imported by sphinxcontrib-typer (docs)
   "click < 8.2",                # click 8.2.* produces empty errors if no args are given
   "jsonschema",
   "sphinx>=7.4,<10",


### PR DESCRIPTION
## Problem

The **Documentation build** CI job is failing repo-wide — every open PR, and `main` too if re-run:

```
sphinx-build -nW --keep-going -b html -T -c docs docs/source docs/_build/html
AttributeError: module 'typer.rich_utils' has no attribute 'STYLE_METAVAR'
```

`typer` **0.26.8** removed `rich_utils.STYLE_METAVAR` and `STYLE_METAVAR_SEPARATOR`. The docs auto-document the Typer CLI via the `.. typer:: sphinx_codelinks.cmd.app` directive from `sphinxcontrib-typer`, which still imports those symbols. Both deps are unpinned (`typer>=0.16.0`, `sphinxcontrib-typer>=0.5.1`), so the build broke the moment 0.26.8 shipped — independent of any PR's content.

| typer | `STYLE_METAVAR` / `STYLE_METAVAR_SEPARATOR` |
|---|---|
| 0.16.0 – 0.26.7 | ✅ present |
| 0.26.8 (latest) | ❌ removed |

## Fix

Cap `typer<0.26.8` in `pyproject.toml`. 0.26.7 has both required symbols, and the runtime CLI only needs `>=0.16.0`, so it's unaffected. Bumping `sphinxcontrib-typer` is **not** an option — even the latest 0.9.0 still references the removed symbols (this likely warrants an upstream issue there as well).

## Verification

`sphinx-build -nW --keep-going` (the exact `tox -e docs-clean` command) builds clean locally with the cap — typer resolves to 0.26.7, `build succeeded`. The committed lockfiles already pin `typer==0.26.7`, confirming that's the last-good version.

Merging this unblocks the Documentation build for `main` and all open PRs.
