### PR TITLE
fix(docs): cap sphinxcontrib-typer <0.9.1 (0.9.1 needs typer.rich_utils.STYLE_TYPES)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ docs = [
   "myst-parser>=4.0.0",
   "sphinx-design>=0.6.1",
   "sphinx-code-tabs>=0.5.5",
-  "sphinxcontrib-typer>=0.5.1",
+  "sphinxcontrib-typer>=0.5.1,<0.9.1", # 0.9.1 imports typer.rich_utils.STYLE_TYPES, absent in the capped typer <0.26.8, breaking the docs build
   "sphinxcontrib-video>=0.4.1",
 ]
 mypy = [


### PR DESCRIPTION
## Problem

`sphinxcontrib-typer 0.9.1` (released after #84) imports
`typer.rich_utils.STYLE_TYPES`, which does not exist in the `typer<0.26.8` range
pinned by #84. Any fresh docs build now resolves `sphinxcontrib-typer 0.9.1` and
fails during `sphinx-build`:

```
AttributeError: module 'typer.rich_utils' has no attribute 'STYLE_TYPES'
```

This affects `main` and every open PR (e.g. #85) on a fresh dependency
resolution. Note #84 capped *typer* for a **different** removed attribute
(`STYLE_METAVAR`); this is a new break originating from the sphinxcontrib-typer
side.

## Fix

Cap `sphinxcontrib-typer>=0.5.1,<0.9.1`. `0.9.0` builds cleanly with the capped
typer `0.26.7`; verified locally that `sphinx-build -nW` no longer raises the
`AttributeError`.

Dependency-only change — no source, tests, or typing impact.
