### PR TITLE
fix(analyse): anchor newline-terminated one-line markers to comment start (#88)

### DIFF
--- a/src/sphinx_codelinks/analyse/oneline_parser.py
+++ b/src/sphinx_codelinks/analyse/oneline_parser.py
@@ -43,6 +43,19 @@ def oneline_parser(  # noqa: PLR0912, PLR0911 # handel warnings
         # start or end sequences do not exist
         return None
 
+    # A marker whose end sequence is the newline extends to the end of the
+    # line, so an unanchored start sequence would swallow trailing prose. Anchor
+    # such a marker to the start of the comment content: everything preceding
+    # the start sequence must be comment decoration (`//`, `#`, `*`, ...) and
+    # whitespace. A word character before it means the start sequence is part of
+    # free-form prose (e.g. `// see @author, ...`) and the line is ignored
+    # (issue #88). Explicitly-bounded markers (e.g. `[[ ... ]]`) are
+    # self-delimiting and may appear anywhere, so they are exempt.
+    if oneline_config.end_sequence == UNIX_NEWLINE and any(
+        char.isalnum() for char in oneline[:start_idx]
+    ):
+        return None
+
     # extract the string wrapped by start and end
     start_idx = start_idx + len(oneline_config.start_sequence)
     string = oneline[start_idx:end_idx].strip()

--- a/tests/test_oneline_parser.py
+++ b/tests/test_oneline_parser.py
@@ -527,3 +527,46 @@ def test_oneline_parser_default_config_negative(
 def test_oneline_schema_validator_negative(oneline_config, result):
     errors = oneline_config.check_fields_configuration()
     assert sorted(errors) == sorted(result)
+
+
+@pytest.mark.parametrize(
+    "oneline",
+    [
+        # A start sequence embedded in free-form prose (word chars before it)
+        # must not be treated as a one-line marker (issue #88).
+        f"// Some prose that mentions @@another-tag(item_1, item_2): more text{UNIX_NEWLINE}",
+        f"// See @author, check the example{UNIX_NEWLINE}",
+        f"// We parse things matching @pattern, then act{UNIX_NEWLINE}",
+    ],
+)
+def test_oneline_parser_ignores_start_sequence_in_prose(oneline: str) -> None:
+    """Issue #88: only anchor a marker at the start of the comment content."""
+    assert oneline_parser(oneline, ONELINE_COMMENT_STYLE_DEFAULT) is None
+
+
+@pytest.mark.parametrize(
+    "oneline, expected_id",
+    [
+        (f"// @My Title, IMPL_1{UNIX_NEWLINE}", "IMPL_1"),  # line-comment leader
+        (f"    // @My Title, IMPL_2{UNIX_NEWLINE}", "IMPL_2"),  # indented
+        (f"* @My Title, IMPL_3{UNIX_NEWLINE}", "IMPL_3"),  # block-comment continuation
+        (f"/// @My Title, IMPL_4{UNIX_NEWLINE}", "IMPL_4"),  # doc comment
+        (f"//! @My Title, IMPL_5{UNIX_NEWLINE}", "IMPL_5"),  # inner doc comment
+    ],
+)
+def test_oneline_parser_marker_preceded_only_by_comment_decoration(
+    oneline: str, expected_id: str
+) -> None:
+    """A marker preceded only by comment syntax/whitespace is still recognized."""
+    res = oneline_parser(oneline, ONELINE_COMMENT_STYLE_DEFAULT)
+    assert isinstance(res, dict)
+    assert res["id"] == expected_id
+
+
+def test_oneline_parser_bounded_marker_allowed_after_prose() -> None:
+    """Explicitly-bounded markers ([[ ... ]]) are self-delimiting, so they may
+    be embedded after prose; only newline-terminated markers are anchored."""
+    oneline = "// one-line comment style: [[IMPL_1, title 1]]"
+    res = oneline_parser(oneline, ONELINE_COMMENT_STYLE)
+    assert isinstance(res, dict)
+    assert res["id"] == "IMPL_1"


### PR DESCRIPTION
## Problem

Fixes #88.

The one-line marker scanner locates the start sequence with `str.find`, so it
matches the sequence (default `@`) **anywhere** in a comment. When `@` appears
inside free-form prose followed by a comma, the text is mis-parsed as
`title, id, …` and the bogus id (with spaces/specials) later fails the
sphinx-needs id regex with `InvalidNeedException`:

```
// See @author, check the example      → id = "check the example"  → InvalidNeedException
// We parse things matching @pattern, then act
// Some prose that mentions @@another-tag(item_1, item_2): more text
```

## Fix

Anchor markers whose `end_sequence` is the newline (i.e. they run to
end-of-line) to the **start of the comment content**: only comment decoration
(`//`, `#`, `*`, `///`, `//!`, …) and whitespace may precede the start sequence.
A word character before it means the sequence is prose, and the line is ignored.

Explicitly-bounded markers (e.g. `[[ … ]]`) are self-delimiting, so they stay
position-independent and may still be embedded after prose — this is what keeps
the recommended bracket-style workaround (and the existing `supercharge.cpp`
fixture) working.

## Tests

- New: the three issue-#88 prose lines are ignored; decoration-prefixed markers
  (line-comment, indented, block `*`, `///`, `//!`) still parse; a bounded
  `[[ … ]]` marker embedded after prose still parses.
- Full suite green (271 passed), mypy clean.

## Workaround (no upgrade required)

Switch the affected project to a self-delimiting bracket style, which does not
collide with `@` in prose:

```toml
[codelinks.projects.<name>.analyse.oneline_comment_style]
start_sequence = "[["
end_sequence   = "]]"
```
